### PR TITLE
Run as root

### DIFF
--- a/o3tanks.sh
+++ b/o3tanks.sh
@@ -277,6 +277,7 @@ build_image()
 		--build-arg USER_GROUP="${USER_GROUP}" \
 		--build-arg USER_UID="${USER_UID}" \
 		--build-arg USER_GID="${USER_GID}" \
+		--build-arg USER_HOME="${USER_HOME}" \
 		"${context_dir}"
 }
 
@@ -737,19 +738,32 @@ init_globals()
 	local host_user_group
 	local host_user_uid
 	local host_user_gid
+	local host_user_home
 	host_user_name=$(id --user --real --name)
 	host_user_group=$(id --group --real --name)
 	host_user_uid=$(id --user --real)
 	host_user_gid=$(id --group --real)
+	host_user_home=$(echo ~)
 	readonly HOST_USER_NAME="${host_user_name}"
 	readonly HOST_USER_GROUP="${host_user_group}"
 	readonly HOST_USER_GID="${host_user_gid}"
 	readonly HOST_USER_UID="${host_user_uid}"
+	readonly HOST_USER_HOME="${host_user_home}"
 
-	readonly USER_NAME='user'
+	local container_user_name
+	local container_user_home
+	if [ "${HOST_USER_NAME}" = 'root' ]; then
+		container_user_name='root'
+		container_user_home="/${container_user_name}"
+	else
+		container_user_name='user'
+		container_user_home="/home/${container_user_name}"
+	fi
+	readonly USER_NAME="${container_user_name}"
 	readonly USER_GROUP="${USER_NAME}"
 	readonly USER_UID="${host_user_uid}"
 	readonly USER_GID="${host_user_gid}"
+	readonly USER_HOME="${container_user_home}"
 
 	local real_user_name
 	local real_user_group
@@ -779,8 +793,9 @@ init_globals()
 	readonly REAL_USER_GROUP="${real_user_group}"
 	readonly REAL_USER_UID="${real_user_uid}"
 	readonly REAL_USER_GID="${real_user_gid}"
+	readonly REAL_USER_HOME="${HOST_USER_HOME}"
 
-	readonly O3DE_ROOT_DIR="/home/${USER_NAME}/o3de"
+	readonly O3DE_ROOT_DIR="${USER_HOME}/o3de"
 	readonly O3DE_GEMS_DIR="${O3DE_ROOT_DIR}/gems"
 	readonly O3DE_GEMS_EXTERNAL_DIR="${O3DE_GEMS_DIR}/.external"
 	readonly O3DE_PROJECT_DIR="${O3DE_ROOT_DIR}/project"
@@ -789,8 +804,8 @@ init_globals()
 	readonly SCRIPTS_PATH="${RECIPES_PATH}/o3tanks"
 
 	readonly DATA_DIR="${O3TANKS_DATA_DIR:-}"
-	readonly RECIPES_DIR="/home/${USER_NAME}/o3tanks_recipes"
-	readonly SCRIPTS_DIR="/home/${USER_NAME}/o3tanks"
+	readonly RECIPES_DIR="${USER_HOME}/o3tanks_recipes"
+	readonly SCRIPTS_DIR="${USER_HOME}/o3tanks"
 }
 
 run_cli()
@@ -1150,6 +1165,7 @@ run_cli()
 		--env O3TANKS_REAL_USER_GROUP="${REAL_USER_GROUP}" \
 		--env O3TANKS_REAL_USER_UID="${REAL_USER_UID}" \
 		--env O3TANKS_REAL_USER_GID="${REAL_USER_GID}" \
+		--env O3TANKS_REAL_USER_HOME="${REAL_USER_HOME}" \
 		${dev_env} \
 		${dev_mount} \
 		${display_env} \

--- a/recipes/Dockerfile.linux
+++ b/recipes/Dockerfile.linux
@@ -36,7 +36,7 @@ ARG USER_NAME
 ARG USER_GROUP
 ARG USER_UID
 ARG USER_GID
-ARG USER_HOME=/home/${USER_NAME}
+ARG USER_HOME
 RUN if [ -z "${USER_NAME}" ] || [ -z "${USER_GROUP}" ] || [ -z "${USER_UID}" ] || [ -z "${USER_GID}" ]; then \
 		echo 'ERROR: At least one user property is missing. Please check your --build-arg values' \
 	 && exit 1 \

--- a/recipes/o3tanks/globals/o3de.py
+++ b/recipes/o3tanks/globals/o3de.py
@@ -16,7 +16,7 @@
 from ..utils.filesystem import is_directory_empty
 from ..utils.subfunctions import get_builds_root_path, get_script_filename, has_configuration
 from ..utils.types import OSFamilies, ObjectEnum
-from .o3tanks import OPERATING_SYSTEM, RUN_CONTAINERS, USER_NAME, init_from_env
+from .o3tanks import OPERATING_SYSTEM, RUN_CONTAINERS, USER_HOME, init_from_env
 import pathlib
 
 
@@ -80,9 +80,9 @@ class O3DE_Variants(ObjectEnum):
 # --- FUNCTIONS ---
 
 def get_default_root_dir():
-	path = "/home/{}/o3de".format(USER_NAME)
+	path = USER_HOME / "o3tanks"
 
-	return (pathlib.PosixPath(path) if RUN_CONTAINERS else pathlib.PurePosixPath(path))
+	return (pathlib.PosixPath(str(path)) if RUN_CONTAINERS else path)
 
 
 def get_build_path(builds_root_dir, variant = O3DE_Variants.NON_MONOLITHIC, operating_system = OPERATING_SYSTEM):

--- a/recipes/o3tanks/globals/o3tanks.py
+++ b/recipes/o3tanks/globals/o3tanks.py
@@ -273,9 +273,9 @@ def get_os():
 
 
 def get_default_root_dir():
-	path = "/home/{}/o3tanks".format(USER_NAME)
+	path = USER_HOME / "o3tanks"
 
-	return (pathlib.PosixPath(path) if RUN_CONTAINERS else pathlib.PurePosixPath(path))
+	return (pathlib.PosixPath(str(path)) if RUN_CONTAINERS else path)
 
 
 def get_default_data_dir(operating_system):
@@ -323,15 +323,17 @@ PRIVATE_PROJECT_SETTINGS_PATH = PRIVATE_PROJECT_EXTRA_PATH / "settings.json"
 ASSET_PROCESSOR_LOCK_PATH = PRIVATE_PROJECT_EXTRA_PATH / "asset-processor.json"
 SERVER_LOCK_PATH = PRIVATE_PROJECT_EXTRA_PATH / "server.json"
 
-USER_NAME = "user"
-USER_GROUP = USER_NAME
-
 REAL_USER = User(
 	init_from_env("O3TANKS_REAL_USER_NAME", str, None),
 	init_from_env("O3TANKS_REAL_USER_GROUP", str, None),
 	init_from_env("O3TANKS_REAL_USER_UID", int, None),
-	init_from_env("O3TANKS_REAL_USER_GID", int, None)
+	init_from_env("O3TANKS_REAL_USER_GID", int, None),
+	init_from_env("O3TANKS_REAL_USER_HOME", pathlib.PurePath, None)
 )
+
+USER_NAME = "root" if REAL_USER.uid == 0 else "user"
+USER_GROUP = USER_NAME
+USER_HOME = pathlib.PurePosixPath("/root") if REAL_USER.uid == 0 else pathlib.PurePosixPath("/home") / USER_NAME
 
 ROOT_DIR = init_from_env("O3TANKS_DIR", pathlib.Path, get_default_root_dir())
 DATA_DIR = init_from_env("O3TANKS_DATA_DIR",pathlib.Path, get_default_data_dir(OPERATING_SYSTEM))

--- a/recipes/o3tanks/utils/containers.py
+++ b/recipes/o3tanks/utils/containers.py
@@ -14,7 +14,7 @@
 
 
 from ..globals.o3de import O3DE_ENGINE_BUILDS_DIR, O3DE_ENGINE_INSTALL_DIR, O3DE_ENGINE_SOURCE_DIR, O3DE_GEMS_DIR, O3DE_GEMS_EXTERNAL_DIR, O3DE_PACKAGES_DIR, O3DE_PROJECT_SOURCE_DIR
-from ..globals.o3tanks import DATA_DIR, DEVELOPMENT_MODE, DISPLAY_ID, GPU_CARD_IDS, GPU_DRIVER_NAME, GPU_RENDER_OFFLOAD, OPERATING_SYSTEM, REAL_USER, RUN_CONTAINERS, ROOT_DIR, USER_NAME, USER_GROUP, GPUDrivers, Images, Volumes, get_version_number
+from ..globals.o3tanks import DATA_DIR, DEVELOPMENT_MODE, DISPLAY_ID, GPU_CARD_IDS, GPU_DRIVER_NAME, GPU_RENDER_OFFLOAD, OPERATING_SYSTEM, REAL_USER, RUN_CONTAINERS, ROOT_DIR, USER_NAME, USER_GROUP, USER_HOME, GPUDrivers, Images, Volumes, get_version_number
 from .filesystem import clear_directory, is_directory_empty
 from .input_output import Level, Messages, get_verbose, print_msg, throw_error
 from .serialization import serialize_list
@@ -90,7 +90,8 @@ class ContainerClient(abc.ABC):
 			"USER_NAME": container_user.name,
 			"USER_GROUP": container_user.group,
 			"USER_UID": str(container_user.uid),
-			"USER_GID": str(container_user.gid)
+			"USER_GID": str(container_user.gid),
+			"USER_HOME": str(container_user.home)
 		}
 
 
@@ -189,7 +190,9 @@ class ContainerClient(abc.ABC):
 		else:
 			throw_error(Messages.INVALID_OPERATING_SYSTEM, OPERATING_SYSTEM.family)
 
-		return User(name, group, uid, gid)
+		home = str(pathlib.Path.home())
+
+		return User(name, group, uid, gid, home)
 
 
 	def is_in_container(self):
@@ -405,7 +408,7 @@ class DockerContainerClient(ContainerClient):
 				container_uid = host_user.uid
 				container_gid = host_user.gid
 
-		return User(USER_NAME, USER_GROUP, container_uid, container_gid)
+		return User(USER_NAME, USER_GROUP, container_uid, container_gid, USER_HOME)
 
 
 	@staticmethod

--- a/recipes/o3tanks/utils/types.py
+++ b/recipes/o3tanks/utils/types.py
@@ -14,6 +14,7 @@
 
 
 import enum
+import pathlib
 import typing
 
 
@@ -136,3 +137,4 @@ class User(typing.NamedTuple):
 	group: str
 	uid: int
 	gid: int
+	home: pathlib.PurePath


### PR DESCRIPTION
The tool is designed not to require additional privileges and run as a standard user, as long as it has access to the socket of Docker Engine. When the daemon cannot be run in rootless mode, there are some corner-cases for root mode where the previous assumption isn't valid. For instance:
1. the user cannot be added to the system group to access the socket directly;
2. the tool is running on a machine where no user mode exists.

As reported in issue #53, the tool is now returning a misleading error if `root` is used to build images. This PR fixes this behavior forcing the use of `root` user inside containers as follows:
- [x] check in the main script if it was launched by a privileged user (i.e. UID is 0);
- [x] switch all script and installations from `/home/user/` to `/root/`;
- [x] propagate the use of `root` user between all containers.

Note that the technical user and all related paths are written at build time, so the resulting images must be used with the same mode that were generated (i.e. images built by `root` must be run by `root` only, whereas any user can run images built by other users).