### PR TITLE
Fix error handling for multiple scenarios

### DIFF
--- a/o3tanks.sh
+++ b/o3tanks.sh
@@ -941,7 +941,7 @@ run_cli()
 	check_cli
 
 	local docker_socket
-	if [ -n "${DOCKER_HOST}" ]; then
+	if [ -n "${DOCKER_HOST:-}" ]; then
 		local docker_protocol
 		docker_protocol=$(extract_substring "${DOCKER_HOST}" ':/' '1')
 

--- a/o3tanks.sh
+++ b/o3tanks.sh
@@ -625,13 +625,16 @@ init_globals()
 	readonly COMMANDS_INIT='init'
 	readonly COMMANDS_INSTALL='install'
 	readonly COMMANDS_OPEN='open'
+	readonly COMMANDS_REFRESH='refresh'
 	readonly COMMANDS_REMOVE='remove'
 	readonly COMMANDS_RUN='run'
 	readonly COMMANDS_SETTINGS='settings'
+	readonly COMMANDS_UPGRADE='upgrade'
 
 	readonly SUBCOMMANDS_ASSETS='assets'
 	readonly SUBCOMMANDS_GEM='gem'
 	readonly SUBCOMMANDS_PROJECT='project'
+	readonly SUBCOMMANDS_SELF='self'
 
 	readonly DISPLAY_TYPES_NONE='none'
 
@@ -1091,7 +1094,17 @@ run_cli()
 
 				project_mount="--mount type=bind,source=${project_dir},destination=${O3DE_PROJECT_DIR}"
 			fi
-			;;	
+			;;
+
+			("${COMMANDS_REFRESH}"|"${COMMANDS_UPGRADE}")
+			local subcommand
+			subcommand="${2:-}"
+			if [ "${subcommand}" = "${SUBCOMMANDS_SELF}" ]; then
+				project_mount="--mount type=bind,source=${BIN_DIR},destination=${O3DE_PROJECT_DIR}"
+			else
+				project_mount=''
+			fi
+			;;
 
 		(*)
 			project_mount=''

--- a/o3tanks.sh
+++ b/o3tanks.sh
@@ -95,7 +95,11 @@ get_message_text()
 			;;
 
 		("${MESSAGES_VOLUMES_DIR_NOT_FOUND}")
-			echo 'Unable to find the volumes storage at: %s'
+			echo 'Unable to find a valid directory for Docker volumes at: %s'
+			;;
+
+		("${MESSAGES_VOLUMES_DIR_PERMISSION_DENIED}")
+			echo 'Unable to access to the Docker directory at: %s.\n Please assign at least the execution permission (x)'
 			;;
 
 		(*)
@@ -664,6 +668,7 @@ init_globals()
 	readonly MESSAGES_UNSUPPORTED_CONTAINTERS_MODE=17
 	readonly MESSAGES_UNSUPPORTED_SELECT_GPU_ID=18
 	readonly MESSAGES_VOLUMES_DIR_NOT_FOUND=19
+	readonly MESSAGES_VOLUMES_DIR_PERMISSION_DENIED=20
 
 	readonly NETWORK_NAMES_NONE='none'
 	local network_name="${O3TANKS_NETWORK:-}"
@@ -966,7 +971,11 @@ run_cli()
 	local docker_volumes_dir
 	docker_volumes_dir="${docker_root_dir}/volumes"
 	if ! [ -d "${docker_volumes_dir}" ]; then
-		throw_error "${MESSAGES_VOLUMES_DIR_NOT_FOUND}"
+		if [ -d "${docker_root_dir}" ] && ! [ -x "${docker_root_dir}" ]; then
+			throw_error "${MESSAGES_VOLUMES_DIR_PERMISSION_DENIED}" "${docker_root_dir}"
+		else
+			throw_error "${MESSAGES_VOLUMES_DIR_NOT_FOUND}" "${docker_volumes_dir}"
+		fi
 	fi
 
 	local project_mount

--- a/recipes/o3tanks/cli.py
+++ b/recipes/o3tanks/cli.py
@@ -1191,7 +1191,14 @@ def apply_engine_updates(engine_version, rebuild):
 		else:
 			save_images = False
 
-		resume_command = [ get_bin_name(), CliCommands.INSTALL.value, print_option(LongOptions.FORCE) ]
+		resume_command = [
+			get_bin_name(),
+			CliCommands.INSTALL.value,
+			CliSubCommands.ENGINE.value,
+			print_option(LongOptions.FORCE),
+			print_option(LongOptions.ALIAS, engine_version)
+		]
+
 		if engine_repository.url != O3DE_REPOSITORY_URL:
 			resume_command.append(print_option(LongOptions.REPOSITORY, engine_repository.url))
 		
@@ -1201,7 +1208,7 @@ def apply_engine_updates(engine_version, rebuild):
 			resume_command.append(print_option(LongOptions.COMMIT, engine_repository.revision))
 
 		if engine_config != O3DE_DEFAULT_CONFIG:
-			resume_command.append(print_option(LongOptions.CONFIG, engine_config))
+			resume_command.append(print_option(LongOptions.CONFIG, engine_config.value))
 
 		if remove_build:
 			resume_command.append(print_option(LongOptions.REMOVE_BUILD))
@@ -1215,7 +1222,6 @@ def apply_engine_updates(engine_version, rebuild):
 			else:
 				resume_command.append(print_option(LongOptions.SAVE_IMAGES, save_images))
 
-		resume_command.append(engine_version)
 		resume_command = ' '.join(resume_command)
 
 		print_msg(Level.INFO, resume_command)
@@ -1234,7 +1240,8 @@ def install_engine(repository, engine_version, engine_config, engine_variant, en
 		get_bin_name(),
 		CliCommands.INSTALL.value,
 		CliSubCommands.ENGINE.value,
-		print_option(LongOptions.FORCE)
+		print_option(LongOptions.FORCE),
+		print_option(LongOptions.ALIAS, engine_version)
 	]
 
 	if repository_url != O3DE_REPOSITORY_URL:
@@ -1247,10 +1254,10 @@ def install_engine(repository, engine_version, engine_config, engine_variant, en
 			resume_command.append(print_option(LongOptions.BRANCH, repository_reference))
 
 	if engine_config != O3DE_DEFAULT_CONFIG:
-		resume_command.append(print_option(LongOptions.CONFIG, engine_config))
+		resume_command.append(print_option(LongOptions.CONFIG, engine_config.value))
 
 	if engine_workflow != O3DE_DEFAULT_WORKFLOW:
-		resume_command.append(print_option(LongOptions.WORKFLOW, engine_workflow))
+		resume_command.append(print_option(LongOptions.WORKFLOW, engine_workflow.value))
 
 	if incremental:
 		resume_command.append(print_option(LongOptions.INCREMENTAL))
@@ -1261,7 +1268,6 @@ def install_engine(repository, engine_version, engine_config, engine_variant, en
 		else:
 			resume_command.append(print_option(LongOptions.SAVE_IMAGES, save_images))
 
-	resume_command.append(engine_version)
 	resume_command = ' '.join(resume_command)
 
 	source_volume = CONTAINER_CLIENT.get_volume_name(Volumes.SOURCE, engine_version)

--- a/recipes/o3tanks/globals/o3de.py
+++ b/recipes/o3tanks/globals/o3de.py
@@ -86,22 +86,34 @@ def get_default_root_dir():
 
 
 def get_build_path(builds_root_dir, variant = O3DE_Variants.NON_MONOLITHIC, operating_system = OPERATING_SYSTEM):
+	if builds_root_dir is None:
+		return None
+
 	return builds_root_dir / "{}{}".format(operating_system.family.value, "_mono" if variant is O3DE_Variants.MONOLITHIC else "")
 
 
 def get_build_bin_path(build_dir, config):
+	if build_dir is None:
+		return None
+
 	return pathlib.Path("{}/bin/{}".format(build_dir, config.value))
 
 
 def get_install_bin_path(install_dir, config, variant = O3DE_Variants.NON_MONOLITHIC, operating_system = OPERATING_SYSTEM):
+	if install_dir is None:
+		return None
+
 	return pathlib.Path("{}/bin/{}/{}/{}".format(install_dir, operating_system.family.value, config.value, "Monolithic" if variant is O3DE_Variants.MONOLITHIC else "Default"))
 
 def get_install_lib_path(install_dir, config, variant = O3DE_Variants.NON_MONOLITHIC, operating_system = OPERATING_SYSTEM):
+	if install_dir is None:
+		return None
+
 	return pathlib.Path("{}/lib/{}/{}/{}".format(install_dir, operating_system.family.value, config.value, "Monolithic" if variant is O3DE_Variants.MONOLITHIC else "Default"))
 
 
 def get_build_workflow(source_dir, build_dir, install_dir):
-	if source_dir.is_dir() and (source_dir / ".git").is_dir() and (source_dir / "engine.json").is_file():
+	if (source_dir is not None ) and source_dir.is_dir() and (source_dir / ".git").is_dir() and (source_dir / "engine.json").is_file():
 		build_workflow = O3DE_BuildWorkflows.PROJECT_CENTRIC_ENGINE_SOURCE
 	else:
 		build_workflow = None
@@ -143,7 +155,7 @@ def has_install_config(install_dir, config, variant):
 		return True
 	
 	lib_dir = get_install_lib_path(install_dir, config, variant)
-	return lib_dir.is_dir() and not is_directory_empty(lib_dir)
+	return (lib_dir is not None) and lib_dir.is_dir() and not is_directory_empty(lib_dir)
 
 
 # --- CONSTANTS ---

--- a/recipes/o3tanks/updater.py
+++ b/recipes/o3tanks/updater.py
@@ -179,11 +179,11 @@ def main():
 
 	if target is None:
 		throw_error(Messages.INVALID_TARGET, sys.argv[2])
-	elif target in [ Targets.ENGINE, Targets.SELF ]:
+	elif target is Targets.ENGINE:
 		repository_dir = O3DE_ENGINE_SOURCE_DIR
 	elif target is Targets.GEM:
 		repository_dir = O3DE_GEMS_DIR
-	elif target is Targets.PROJECT:
+	elif target in [ Targets.PROJECT, Targets.SELF ]:
 		repository_dir = O3DE_PROJECT_SOURCE_DIR
 	else:
 		throw_error(Messages.INVALID_TARGET, target)

--- a/recipes/o3tanks/utils/filesystem.py
+++ b/recipes/o3tanks/utils/filesystem.py
@@ -17,6 +17,7 @@ from .input_output import Level, Messages, ask_for_confirmation, print_msg, thro
 from .types import JsonPropertyKey, ObjectEnum
 import configparser
 import json
+import os
 import shutil
 
 
@@ -38,6 +39,19 @@ def calculate_size(path):
 		bytes_size = 0
 
 	return bytes_size
+
+
+def change_owner(path, user):
+	if (path is None) or (user is None):
+		return None
+
+	os.chown(path, user.uid, user.gid)
+
+	for content in path.iterdir():
+		if content.is_dir():
+			change_owner(content, user)
+
+		os.chown(content, user.uid, user.gid)
 
 
 def clear_directory(path, require_confirmation = False):

--- a/recipes/o3tanks/utils/input_output.py
+++ b/recipes/o3tanks/utils/input_output.py
@@ -214,6 +214,7 @@ class Messages(AutoEnum):
 	START_EXPORT_SAVE_IMAGE = enum.auto()
 	UNCOMPLETED_ADD_GEM = enum.auto()
 	UNCOMPLETED_BUILD_PROJECT = enum.auto()
+	UNCOMPLETED_CHANGE_OWNERSHIP = enum.auto()
 	UNCOMPLETED_CHECK_GEM_RESOLVE_RELATIVE_PATH = enum.auto()
 	UNCOMPLETED_EXPORT = enum.auto()
 	UNCOMPLETED_IMAGE = enum.auto()
@@ -667,6 +668,8 @@ def get_message_text(message_id, *args, **kwargs):
 		message_text = "An error occured while adding the gem to the project (error: {}) {}"
 	elif message_id == Messages.UNCOMPLETED_BUILD_PROJECT:
 		message_text = "An unexpected error could be occurred while building the project"
+	elif message_id == Messages.UNCOMPLETED_CHANGE_OWNERSHIP:
+		message_text = "An error occurred while changing the ownership for: {}\n{}"
 	elif message_id == Messages.UNCOMPLETED_CHECK_GEM_RESOLVE_RELATIVE_PATH:
 		message_text = "An error occurred while writing the absolute path for: {}"
 	elif message_id == Messages.UNCOMPLETED_EXPORT:

--- a/recipes/o3tanks/utils/subfunctions.py
+++ b/recipes/o3tanks/utils/subfunctions.py
@@ -140,7 +140,7 @@ def get_script_filename(name):
 
 
 def has_configuration(config_dir):
-	return config_dir.is_dir() and (
+	return (config_dir is not None) and config_dir.is_dir() and (
 		(config_dir / get_binary_filename("Editor")).is_file() or
 		any(config_dir.glob(get_binary_filename("**/*.GameLauncher"))) or
 		any(config_dir.glob(get_binary_filename("**/*.ServerLauncher")))


### PR DESCRIPTION
This PR fixes minor errors that occur in the following scenarios:
- the tool crashes when the `DOCKER_HOST` variable is not set (resolve #55);
- a misleading error message is returned when the Docker directory exists, but it is restricted for the current user (resolve #56);
- the tool crashes when the Docker configuration cannot be retrieved, or any other required path is invalid;
- the command that is suggested for resuming the execution after a manual action has an invalid syntax due to missing parameters (resolve #58);
- unable to upgrade the tool itself due to invalid permissions (resolve #60).

There are no changes to the main features of the tool.