### PR TITLE
Upgrade the default system to Ubuntu 24.04

### DIFF
--- a/o3tanks.sh
+++ b/o3tanks.sh
@@ -731,7 +731,7 @@ init_globals()
 			os_version=$(extract_substring "${os_value}" ':' '2')
 		else
 			os_name="${OS_NAMES_UBUNTU}"
-			os_version='22.04'
+			os_version='24.04'
 		fi
 	else
 		os_family=''

--- a/recipes/Dockerfile.linux
+++ b/recipes/Dockerfile.linux
@@ -41,6 +41,9 @@ RUN if [ -z "${USER_NAME}" ] || [ -z "${USER_GROUP}" ] || [ -z "${USER_UID}" ] |
 		echo 'ERROR: At least one user property is missing. Please check your --build-arg values' \
 	 && exit 1 \
   ; fi \
+ && if [ "${OS_NAME}" = "ubuntu" ] && [ "${OS_VERSION}" > 23.10 ]; then \
+		userdel ubuntu \
+  ; fi \
  && if [ ${USER_GID} -gt 0 ]; then \
  		groupadd \
 			--gid "${USER_GID}" \

--- a/recipes/o3tanks/globals/o3tanks.py
+++ b/recipes/o3tanks/globals/o3tanks.py
@@ -248,7 +248,7 @@ def get_os():
 
 			else:
 				os_name = LinuxOSNames.UBUNTU
-				os_version = "22.04"
+				os_version = "24.04"
 
 		else:
 			os_name = None

--- a/recipes/o3tanks/utils/input_output.py
+++ b/recipes/o3tanks/utils/input_output.py
@@ -705,7 +705,7 @@ def get_message_text(message_id, *args, **kwargs):
 	elif message_id == Messages.UNSUPPORTED_CONTAINERS_AND_NO_CLIENT:
 		message_text = "No action can be performed on containers when they are disabled"
 	elif message_id == Messages.UNSUPPORTED_OPERATING_SYSTEM_FOR_REQUIREMENTS:
-		message_text = "Unable to verify requirements since your distro isn't supported yet.\nYou can try to convert the following instructions for 'Ubuntu 22.04':"
+		message_text = "Unable to verify requirements since your distro isn't supported yet.\nYou can try to convert the following instructions for 'Ubuntu 24.04':"
 	elif message_id == Messages.UNSUPPORTED_INSERT_SETTING_SECTION:
 		message_text = "A setting section cannot be autopopulated. Please set each field using a dedicated '" + print_command(CliCommands.SETTINGS) + "' command"
 	elif message_id == Messages.UPDATES_AVAILABLE:

--- a/recipes/packages/package_manager.sh
+++ b/recipes/packages/package_manager.sh
@@ -516,7 +516,7 @@ install_packages()
 			setup_command=''
 			refresh_command=''
 			clean_command=''
-			install_package_command="${PYTHON_BIN_FILE} -m pip install"
+			install_package_command="${PYTHON_BIN_FILE} -m pip install --break-system-packages"
 			install_collection_command=''
 			if [ "${manual_installation}" = 'false' ]; then
 				install_package_command="${install_package_command} --no-cache-dir"

--- a/recipes/packages/package_manager.sh
+++ b/recipes/packages/package_manager.sh
@@ -1097,8 +1097,8 @@ main()
 			fi
 
 			local default_os_name="${OS_NAMES_UBUNTU}"
-			local default_os_version="22.04"
-			local default_os_codename="jammy"
+			local default_os_version="24.04"
+			local default_os_codename="noble"
 
 			local install_external_packages
 			if [ "${1}" = '--no-external' ]; then

--- a/recipes/packages/python/any.cfg
+++ b/recipes/packages/python/any.cfg
@@ -1,5 +1,5 @@
 [cli]
-docker = 6.1.2
+docker = 7.1.0
 
 [updater]
-pygit2 = 1.12.1
+pygit2 = 1.15.1

--- a/recipes/packages/system/ubuntu.cfg
+++ b/recipes/packages/system/ubuntu.cfg
@@ -4,7 +4,7 @@ python3 =
 [development]
 @build-essential =
 ca-certificates =
-clang-14 =
+clang =
 cmake =
 git =
 libcurl4-openssl-dev =

--- a/recipes/packages/system/ubuntu_22.04.cfg
+++ b/recipes/packages/system/ubuntu_22.04.cfg
@@ -1,0 +1,83 @@
+[base]
+python3 =
+
+[development]
+@build-essential =
+ca-certificates =
+clang-14 =
+cmake =
+git =
+libcurl4-openssl-dev =
+libfontconfig1-dev =
+libglu1-mesa-dev =
+libsdl2-dev =
+libssl-dev =
+libunwind-dev =
+libxcb-xfixes0-dev =
+libxcb-xinput-dev =
+libxcb-xkb-dev =
+libxkbcommon-dev =
+libxkbcommon-x11-dev =
+libzstd-dev =
+mesa-common-dev =
+ninja-build =
+zlib1g-dev =
+
+[development_external]
+
+[gpu_amd]
+mesa-vulkan-drivers =
+
+[gpu_intel]
+mesa-vulkan-drivers =
+
+[runner]
+libxcb-icccm4 =
+libxcb-image0 =
+libxcb-keysyms1 =
+libxcb-randr0 =
+libxcb-render0 =
+libxcb-render-util0 =
+libxcb-shape0 =
+
+[runtime]
+libatomic1 =
+libcurl4 =
+libdbus-1-3 =
+libfontconfig1 =
+libfreetype6 =
+libgl1 =
+libglib2.0-0 =
+libice6 =
+libopengl0 =
+libpcre2-16-0 =
+libsm6 =
+libssl3 =
+libunwind8 =
+libvulkan1 =
+libwebp7 =
+libwebpdemux2 =
+libwebpmux3 =
+libx11-6 =
+libx11-xcb1 =
+libxcb1 =
+libxcb-glx0 =
+libxcb-shm0 =
+libxcb-sync1 =
+libxcb-xfixes0 =
+libxcb-xinerama0 =
+libxcb-xinput0 =
+libxcb-xkb1 =
+libxext6 =
+libxfixes3 =
+libxi6 =
+libxkbcommon0 =
+libxkbcommon-x11-0 =
+libxrender1 =
+libzstd1 =
+
+[runtime_external]
+
+[scripts]
+python3-pip =
+python3-setuptools =


### PR DESCRIPTION
Closes #64.

Note that Ubuntu 24.04 uses Python 3.12, which enforces the use of virtual environments when PIP is used to install packages. The check is disabled as a temporary fix to keep the current behavior, but it will be improved in a future Pull Request.